### PR TITLE
Fix bug in EphemeralRandomConstantNode

### DIFF
--- a/simplegp/Nodes/SymbolicRegressionNodes.py
+++ b/simplegp/Nodes/SymbolicRegressionNodes.py
@@ -148,4 +148,4 @@ class EphemeralRandomConstantNode(Node):
 	def GetOutput(self,X):
 		if np.isnan(self.c):
 			self.__Instantiate()
-		return self.c
+		return np.array([self.c] * len(X))


### PR DESCRIPTION
Currently, the `GetOutput` function returns a single constant for the node. This typically goes well, since this result is multiplied with other arrays from other nodes, but when the constant is the only node in the function, you get only a one-dimensional output. It should have the shape (length) of `X`, instead. (We came across this by accident, where we encountered the rare case where this went wrong.) This PR fixes this.